### PR TITLE
maven is no longer Alpine

### DIFF
--- a/ci.adoc
+++ b/ci.adoc
@@ -27,7 +27,7 @@ The agent images are all built from the link:https://github.com/jenkinsci/jnlp-a
 
 To use a container agent, specify one of the following labels:
 
-* `maven`: A Maven 3 (Alpine) container with JDK8
+* `maven`: A Maven 3 (Debian) container with JDK8
 * `maven-11`: A maven 3 (Debian) container with JDK11
 * `node`: A Node (Alpine) container
 * `ruby` :  A Ruby 2 (Debian) container


### PR DESCRIPTION
…as of https://github.com/jenkinsci/jnlp-agents/pull/2.