### PR TITLE
Document latest agent labels

### DIFF
--- a/ci.adoc
+++ b/ci.adoc
@@ -15,6 +15,7 @@ when referencing nodes, e.g. in the `Jenkinsfile`.
 * `windows` : A Windows 2019 provisioned on Azure or AWS
 * `highmem` : A Linux (Ubuntu 18.04 LTS) instance with 4vCPU/28GB RAM
 (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard A6]). Please avoid unless running ATH or other high-memory capacity instances.
+* `windock` : A Windows 2019 provisioned on Azure or AWS that is able to run Windows Docker images
 * `puppet` : A Linux (Ubuntu 14.04 LTS) instance that is managed by link:https://github.com/jenkins-infra/jenkins-infra/blob/staging/dist/profile/manifests/buildslave.pp[this Puppet code]
 
 ==== Container Agents

--- a/ci.adoc
+++ b/ci.adoc
@@ -18,6 +18,13 @@ when referencing nodes, e.g. in the `Jenkinsfile`.
 * `windock` : A Windows 2019 provisioned on Azure or AWS that is able to run Windows Docker images
 * `puppet` : A Linux (Ubuntu 14.04 LTS) instance that is managed by link:https://github.com/jenkins-infra/jenkins-infra/blob/staging/dist/profile/manifests/buildslave.pp[this Puppet code]
 
+==== Node Labels - Processors
+
+* `amd64` : An agent running an AMD or Intel 64 bit processor
+* `arm64` : An agent running an ARM 64 bit processor on AWS (Amazon Graviton)
+* `ppc64le` : An agent running an IBM PowerPC 64 bit processor
+* `s390x` : An agent running an IBM System 390x (Z series) processor
+
 ==== Container Agents
 
 We have link:https://azure.microsoft.com/en-us/services/container-instances/[Azure Container Instances] deployed which can

--- a/ci.adoc
+++ b/ci.adoc
@@ -12,8 +12,7 @@ when referencing nodes, e.g. in the `Jenkinsfile`.
 
 * `linux` : A Linux (Ubuntu 18.04 LTS) instance (alias of `java`)
 * `docker` : A Linux (Ubuntu 18.04 LTS) instance with a running Docker daemon
-* `windows` : A "stock" Windows 2012 R2 provisioned on Azure
-(link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard D3 v2])
+* `windows` : A Windows 2019 provisioned on Azure or AWS
 * `highmem` : A Linux (Ubuntu 18.04 LTS) instance with 4vCPU/28GB RAM
 (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard A6]). Please avoid unless running ATH or other high-memory capacity instances.
 * `puppet` : A Linux (Ubuntu 14.04 LTS) instance that is managed by link:https://github.com/jenkins-infra/jenkins-infra/blob/staging/dist/profile/manifests/buildslave.pp[this Puppet code]

--- a/ci.adoc
+++ b/ci.adoc
@@ -35,7 +35,9 @@ The agent images are all built from the link:https://github.com/jenkinsci/jnlp-a
 To use a container agent, specify one of the following labels:
 
 * `maven`: A Maven 3 (Debian) container with JDK8
+* `maven-windows`: A maven 3 Windows container with JDK8
 * `maven-11`: A maven 3 (Debian) container with JDK11
+* `maven-11-windows`: A maven 3 Windows container with JDK11
 * `node`: A Node (Alpine) container
 * `ruby` :  A Ruby 2 (Debian) container
 * `alpine` : An Alpine-based container with no additional tooling.


### PR DESCRIPTION
## Document the latest ci.jenkins.io agent labels

* maven-windows and maven-11-windows for Maven on Windows ACI
* windock for Docker on Windows
* amd64, arm64, ppc64la, and s390x for processor specific use

Also notes that we're using Windows Server 2019, not Windows Server 2012.

See #7 from @jglick for better phrasing on several of the items