### PR TITLE
fix: replace 'windock' label by 'docker-windows' (INFRA-3099)

### DIFF
--- a/ci.adoc
+++ b/ci.adoc
@@ -13,14 +13,14 @@ when referencing nodes, e.g. in the `Jenkinsfile`.
 * `linux` \ `docker` (alias of `java`): A Linux (Ubuntu 20.04 LTS) instance with Docker Engine Community Edition
 ** On AWS (label `aws`): https://github.com/jenkins-infra/jenkins-infra/blob/production/hieradata/clients/azure.ci.jenkins.io.yaml#L121[]
 ** On Azure: https://github.com/jenkins-infra/jenkins-infra/blob/production/hieradata/clients/azure.ci.jenkins.io.yaml#L172[] 
-* `windows` : A Windows 2019 instance with 4~8vCPU/16GB RAM provisioned (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard_D4s_v3] on Azure or link:https://aws.amazon.com/en/ec2/instance-types/[T3Xlarge] on AWS)
+* `windows` : A Windows 2019 instance with 4vCPU/16GB RAM provisioned (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard_D4s_v3] on Azure or link:https://aws.amazon.com/en/ec2/instance-types/[T3Xlarge] on AWS)
 * `highmem` : A Linux (Ubuntu 20.04 LTS) instance with 16vCPU/64GB RAM
 (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard_D16s_v3] on Azure or link:https://aws.amazon.com/en/ec2/instance-types/[M54xlarge] on AWS). Please avoid unless running ATH or other high-memory capacity instances.
 * `docker-highmem` : A Linux (Ubuntu 20.04 LTS) instance with 16vCPU/64GB RAM and a running Docker daemon
 (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard_D16s_v3] on Azure or link:https://aws.amazon.com/en/ec2/instance-types/[M54xlarge] on AWS). Please avoid unless running ATH or other high-memory capacity instances.
 * `arm64docker` : An ARM64 Linux (Ubuntu 20.04 LTS) instance with 4vCPU/16GB RAM and a running Docker daemon
 (link:https://aws.amazon.com/en/ec2/instance-types/[A1Xlarge] on AWS)
-* `docker-windows` : A Windows 2019 instance with 4~8vCPU/16GB RAM provisioned (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard_D4s_v3] on Azure or link:https://aws.amazon.com/en/ec2/instance-types/[T3Xlarge] on AWS) that is able to run Windows Docker images
+* `docker-windows` : A Windows 2019 instance with 4vCPU/16GB RAM provisioned (link:https://azure.microsoft.com/en-us/documentation/articles/cloud-services-sizes-specs/[Standard_D4s_v3] on Azure or link:https://aws.amazon.com/en/ec2/instance-types/[T3Xlarge] on AWS) that is able to run Windows Docker images
 
 ==== Node Labels - Processors
 


### PR DESCRIPTION
Following https://github.com/jenkins-infra/jenkins-infra/pull/1936, replace 'windock' label by 'docker-windows'
See https://issues.jenkins.io/browse/INFRA-3099?focusedCommentId=414936
