### PR TITLE
Add a section about Artifact Caching Proxy in ci.adoc

### DIFF
--- a/ci.adoc
+++ b/ci.adoc
@@ -129,13 +129,13 @@ Additionally, https://repo.azure.jenkins.io/ mirrors all non-snapshot downloads 
 
 == Artifact Caching Proxy
 
-The [artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/2752) is a mechanism we've put in place using [nginx proxy](https://github.com/jenkins-infra/helm-charts/blob/main/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml) in front of repo.jenkins-ci.org (our JFrog sponsored Artifactory instance) and Maven Central to cache artifact download requests.
+The https://github.com/jenkins-infra/helpdesk/issues/2752[artifact caching proxy] is a mechanism we've put in place using https://github.com/jenkins-infra/helm-charts/blob/main/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml[nginx proxy] in front of repo.jenkins-ci.org (our JFrog sponsored Artifactory instance) and Maven Central to cache artifact download requests.
 
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 
 In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities: +
 - Temporarily, on your pull request add a `skip-artifact-caching-proxy` label +
-- Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to [the recommanded `buildPlugin` configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile), ex: +
+- Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex: +
 ```
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests

--- a/ci.adoc
+++ b/ci.adoc
@@ -138,8 +138,7 @@ In case you need for whatever reason to disable this mechanism (discouraged), yo
 * Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
 * Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex:
 
-  [source]
-  Jenkinsfile
+  [source,groovy]
   ----
   buildPlugin(
     useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests

--- a/ci.adoc
+++ b/ci.adoc
@@ -137,7 +137,8 @@ In case you need for whatever reason to disable this mechanism (discouraged), yo
 
 * Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
 * Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex:
-  [source,groovy]
+
+  [source]
   Jenkinsfile
   ----
   buildPlugin(

--- a/ci.adoc
+++ b/ci.adoc
@@ -137,7 +137,9 @@ In case you need for whatever reason to disable this mechanism (discouraged), yo
 
 * Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
 * Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex:
-  ```
+  [source,groovy]
+  Jenkinsfile
+  ----
   buildPlugin(
     useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
     useArtifactCachingProxy: false,
@@ -145,4 +147,4 @@ In case you need for whatever reason to disable this mechanism (discouraged), yo
       [platform: 'linux', jdk: 17],
       [platform: 'windows', jdk: 11],
   ])
-  ```
+  ----

--- a/ci.adoc
+++ b/ci.adoc
@@ -134,8 +134,8 @@ The [artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/27
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 
 In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities:
-- on your pull request, add a `skip-artifact-caching-proxy` label
-- in your Jenkinsfile, add `useArtifactCachingProxy: false` to [the recommanded `buildPlugin` configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile), ex:
+- Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
+- Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to [the recommanded `buildPlugin` configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile), ex:
 ```
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests

--- a/ci.adoc
+++ b/ci.adoc
@@ -129,7 +129,7 @@ Additionally, https://repo.azure.jenkins.io/ mirrors all non-snapshot downloads 
 
 == Artifact Caching Proxy
 
-The [artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/2752) is a mechanism we've put in place using [nginx proxy](https://github.com/jenkins-infra/helm-charts/blob/main/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml) in front of repo.jenkins-ci.org (our JFrog sponsored Artifactory instance) and Maven Central to cache artifacts download requests.
+The [artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/2752) is a mechanism we've put in place using [nginx proxy](https://github.com/jenkins-infra/helm-charts/blob/main/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml) in front of repo.jenkins-ci.org (our JFrog sponsored Artifactory instance) and Maven Central to cache artifact download requests.
 
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 

--- a/ci.adoc
+++ b/ci.adoc
@@ -134,14 +134,15 @@ The https://github.com/jenkins-infra/helpdesk/issues/2752[artifact caching proxy
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 
 In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities:
+
 * Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
 * Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex:
-```
-buildPlugin(
-  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-  useArtifactCachingProxy: false,
-  configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 11],
-])
-```
+  ```
+  buildPlugin(
+    useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+    useArtifactCachingProxy: false,
+    configurations: [
+      [platform: 'linux', jdk: 17],
+      [platform: 'windows', jdk: 11],
+  ])
+  ```

--- a/ci.adoc
+++ b/ci.adoc
@@ -136,15 +136,17 @@ The main goals are to decrease the consumed bandwidth (many terabytes per month)
 In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities:
 
 * Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
-* Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex:
+* Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration]
 
-  [source,groovy]
-  ----
-  buildPlugin(
-    useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-    useArtifactCachingProxy: false,
-    configurations: [
-      [platform: 'linux', jdk: 17],
-      [platform: 'windows', jdk: 11],
-  ])
-  ----
+Ex:
+
+[source,groovy]
+----
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useArtifactCachingProxy: false,
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])
+----

--- a/ci.adoc
+++ b/ci.adoc
@@ -134,8 +134,8 @@ The https://github.com/jenkins-infra/helpdesk/issues/2752[artifact caching proxy
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 
 In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities: +
-- Temporarily, on your pull request add a `skip-artifact-caching-proxy` label +
-- Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex: +
+* Temporarily, on your pull request add a `skip-artifact-caching-proxy` label +
+* Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex: +
 ```
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests

--- a/ci.adoc
+++ b/ci.adoc
@@ -126,3 +126,22 @@ Additionally, https://repo.azure.jenkins.io/ mirrors all non-snapshot downloads 
     </mirrors>
 </settings>
 ----
+
+== Artifact Caching Proxy
+
+The [artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/2752) is a mechanism we've put in place using [nginx proxy](https://github.com/jenkins-infra/helm-charts/blob/main/charts/artifact-caching-proxy/templates/nginx-proxy-configmap.yaml) in front of repo.jenkins-ci.org (our JFrog sponsored Artifactory instance) and Maven Central to cache artifacts download requests.
+
+The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
+
+In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities:
+- on your pull request, add a `skip-artifact-caching-proxy` label
+- in your Jenkinsfile, add `useArtifactCachingProxy: false` to [the recommanded `buildPlugin` configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile), ex:
+```
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  useArtifactCachingProxy: false,
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])
+```

--- a/ci.adoc
+++ b/ci.adoc
@@ -133,9 +133,9 @@ The https://github.com/jenkins-infra/helpdesk/issues/2752[artifact caching proxy
 
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 
-In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities: +
-* Temporarily, on your pull request add a `skip-artifact-caching-proxy` label +
-* Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex: +
+In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities:
+* Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
+* Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile[the recommanded `buildPlugin` configuration], ex:
 ```
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests

--- a/ci.adoc
+++ b/ci.adoc
@@ -133,9 +133,9 @@ The [artifact caching proxy](https://github.com/jenkins-infra/helpdesk/issues/27
 
 The main goals are to decrease the consumed bandwidth (many terabytes per month) and to increase Jenkins infrastructure reliability and resilience.
 
-In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities:
-- Temporarily, on your pull request add a `skip-artifact-caching-proxy` label
-- Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to [the recommanded `buildPlugin` configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile), ex:
+In case you need for whatever reason to disable this mechanism (discouraged), you have two possibilities: +
+- Temporarily, on your pull request add a `skip-artifact-caching-proxy` label +
+- Permanently, in your Jenkinsfile add `useArtifactCachingProxy: false` to [the recommanded `buildPlugin` configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/Jenkinsfile), ex: +
 ```
 buildPlugin(
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests


### PR DESCRIPTION
Noticed via [a recent help desk issue](https://github.com/jenkins-infra/helpdesk/issues/3501) that there was no mention of the ACP in CI documentation, this PR resolves this.